### PR TITLE
Capitalise

### DIFF
--- a/source/administrator/components/com_emailscheduler/helpers/abstract.php
+++ b/source/administrator/components/com_emailscheduler/helpers/abstract.php
@@ -22,7 +22,7 @@ class HelperAbstract
 	static public function getStructure()
 	{
 		return array(
-			'title'            => 'Emailscheduler',
+			'title'            => 'EmailScheduler',
 			'menu'             => array(
 				'home'      => 'Home',
 				'emails'    => 'Emails',


### PR DESCRIPTION
This simple PR changes the text in the array to EmailScheduler from Emailscheduler

This is used in the View titles and making this change ensures consistency